### PR TITLE
upgrade helm to 2.16.0 with k8 1.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM openjdk:8-jdk-alpine
 
 # FROM: https://aur.archlinux.org/packages/kubectl-bin/
-ENV K8_VERSION="v1.11.3"
+ENV K8_VERSION="v1.14.0"
 # FROM: https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.11.0"
+ENV HELM_VERSION="v2.16.0"
 ENV HEPTIO_AUTHENTICATOR_VERSION="0.3.0"
 
 RUN apk add --no-cache ca-certificates bash git gnupg jq py-pip 
 RUN apk add --update -t deps curl gettext 
 RUN pip install awscli 
-RUN curl -s -L https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl 
+RUN curl -s -L https://storage.googleapis.com/kubernetes-release/release/${K8_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl 
 RUN chmod +x /usr/local/bin/kubectl 
 RUN curl -s -L https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar -xzO linux-amd64/helm > /usr/local/bin/helm 
 RUN chmod +x /usr/local/bin/helm 


### PR DESCRIPTION
1. Updating versions of helm and k8
2. Change  k8 curl to use the ENV instead of hardcoded value